### PR TITLE
show perf statistics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipet @ git+https://github.com/scipopt/ipet.git@v1.1.2
+ipet @ git+https://github.com/scipopt/ipet.git@v1.2.0
 Click==8.2.1
 elasticsearch==9.2.1
 lxml==6.1.0

--- a/rubberband/constants.py
+++ b/rubberband/constants.py
@@ -21,48 +21,48 @@ STATIC_FILES_DIR = FILES_DIR + "xml/"
 ADD_READERS = STATIC_FILES_DIR + "additional_readers.xml"
 IPET_EVALUATIONS = {
     0: {
-        "path": STATIC_FILES_DIR + "eval_singleruns_exclude.xml",
-        "name": "single runs - exclude fails & aborts (standard)",
-    },
-    1: {
-        "path": STATIC_FILES_DIR + "eval_singleruns_include.xml",
-        "name": "single runs - include fails & aborts (standard)",
-    },
-    2: {
-        "path": STATIC_FILES_DIR + "eval_singleruns_punish.xml",
-        "name": "single runs - punish fails & aborts (standard)",
-    },
-    3: {
-        "path": STATIC_FILES_DIR + "eval_groupgithash_exclude.xml",
-        "name": "group by githash - exclude fails & aborts",
-    },
-    4: {
-        "path": STATIC_FILES_DIR + "eval_groupsettings_exclude.xml",
-        "name": "group by settings - exclude fails & aborts",
-    },
-    5: {
-        "path": STATIC_FILES_DIR + "eval_grouplpsolver_exclude.xml",
-        "name": "group by LP solver - exclude fails & aborts",
-    },
-    6: {
-        "path": STATIC_FILES_DIR + "eval_groupsettings_exclude_detailed.xml",
-        "name": "detailed view - group settings, exclude",
-    },
-    7: {
-        "path": STATIC_FILES_DIR + "eval_groupsettings_include_detailed.xml",
-        "name": "detailed view - group settings, include",
-    },
-    8: {
         "path": STATIC_FILES_DIR + "eval_groupgithash_exclude_detailed.xml",
         "name": "detailed view - group githash, exclude",
     },
-    9: {
-        "path": STATIC_FILES_DIR + "evalperf_groupsettings_exclude_detailed.xml",
-        "name": "perf analysis - detailed, group settings, exclude",
+    1: {
+        "path": STATIC_FILES_DIR + "eval_groupsettings_exclude_detailed.xml",
+        "name": "detailed view - group settings, exclude",
     },
-    10: {
+    2: {
+        "path": STATIC_FILES_DIR + "eval_groupsettings_include_detailed.xml",
+        "name": "detailed view - group settings, include",
+    },
+    3: {
+        "path": STATIC_FILES_DIR + "eval_singleruns_exclude.xml",
+        "name": "single runs - exclude fails & aborts (standard)",
+    },
+    4: {
+        "path": STATIC_FILES_DIR + "eval_singleruns_include.xml",
+        "name": "single runs - include fails & aborts (standard)",
+    },
+    5: {
+        "path": STATIC_FILES_DIR + "eval_singleruns_punish.xml",
+        "name": "single runs - punish fails & aborts (standard)",
+    },
+    6: {
+        "path": STATIC_FILES_DIR + "eval_groupgithash_exclude.xml",
+        "name": "group by githash - exclude fails & aborts",
+    },
+    7: {
+        "path": STATIC_FILES_DIR + "eval_groupsettings_exclude.xml",
+        "name": "group by settings - exclude fails & aborts",
+    },
+    8: {
+        "path": STATIC_FILES_DIR + "eval_grouplpsolver_exclude.xml",
+        "name": "group by LP solver - exclude fails & aborts",
+    },
+    9: {
         "path": STATIC_FILES_DIR + "evalperf_groupgithash_exclude_detailed.xml",
         "name": "perf analysis - detailed, group githash, exclude",
+    },
+    10: {
+        "path": STATIC_FILES_DIR + "evalperf_groupsettings_exclude_detailed.xml",
+        "name": "perf analysis - detailed, group settings, exclude",
     },
     11: {
         "path": STATIC_FILES_DIR + "papilo_evaluation.xml",

--- a/rubberband/constants.py
+++ b/rubberband/constants.py
@@ -57,14 +57,22 @@ IPET_EVALUATIONS = {
         "name": "detailed view - group githash, exclude",
     },
     9: {
+        "path": STATIC_FILES_DIR + "evalperf_groupsettings_exclude_detailed.xml",
+        "name": "perf analysis - detailed, group settings, exclude",
+    },
+    10: {
+        "path": STATIC_FILES_DIR + "evalperf_groupgithash_exclude_detailed.xml",
+        "name": "perf analysis - detailed, group githash, exclude",
+    },
+    11: {
         "path": STATIC_FILES_DIR + "papilo_evaluation.xml",
         "name": "evaluation papilo",
     },
-    10: {
+    12: {
         "path": STATIC_FILES_DIR + "papilo_evaluation_solver_specific.xml",
         "name": "evaluation papilo solver specific",
     },
-    11: {
+    13: {
         "path": STATIC_FILES_DIR + "papilo_evaluation_groupsettings.xml",
         "name": "evaluation papilo group settings",
     },

--- a/rubberband/handlers/api/comparison.py
+++ b/rubberband/handlers/api/comparison.py
@@ -72,12 +72,15 @@ class ComparisonEndpoint(BaseHandler):
         # evaluate with ipet
         ex, _ = setup_experiment(testruns + [baserun], "")
         evalstring = """<?xml version="1.0" ?>
-<Evaluation comparecolformat="%.3f" index="ProblemName Seed Permutation GitHash"
-    indexsplit="-1" fillin="True">
-    <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5"
-    comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit"
-    reduction="shmean shift. by 1">
+<Evaluation comparecolformat="%.3f" index="ProblemName Seed Permutation GitHash" indexsplit="-1" fillin="True">
+    <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
+    <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="shmean shift. by 100">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>
     <Column formatstr="%.2f" origcolname="TimeLimit" alternative="{tl}"
         reduction="mean">
@@ -86,6 +89,12 @@ class ComparisonEndpoint(BaseHandler):
     <FilterGroup name="clean">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup name="affected" filtertype="intersection">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="one" datakey="LP_Iterations_dualLP" operator="diff"/>
+        <Filter active="True" anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
     </FilterGroup>
     <FilterGroup name="all-optimal">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
@@ -109,56 +118,111 @@ class ComparisonEndpoint(BaseHandler):
             cleanindex = ("clean", comparehash)
             allindex = ("all", comparehash)
             alloptindex = ("all-optimal", comparehash)
+            affindex = ("affected", comparehash)
             commithash = comparehash
         else:
             cleanindex = ("clean", basehash)
             allindex = ("all", basehash)
             alloptindex = ("all-optimal", basehash)
+            affindex = ("affected", basehash)
             commithash = basehash
 
         allcount = aggtable["_count_"][allindex]
         allsolved = aggtable["_solved_"][allindex]
         alltime = aggtable["T_sgm(1.0)"][allindex]
+        allnrmtime = aggtable["NrmT_sgm(1.0)"][allindex]
+        allnodes = aggtable["N_sgm(100.0)"][allindex]
         cleancount = aggtable["_count_"][cleanindex]
         cleansolved = aggtable["_solved_"][cleanindex]
         cleantime = aggtable["T_sgm(1.0)"][cleanindex]
+        cleannrmtime = aggtable["NrmT_sgm(1.0)"][cleanindex]
+        cleannodes = aggtable["N_sgm(100.0)"][cleanindex]
         if alloptindex in aggtable["_count_"] :
             alloptcount = aggtable["_count_"][alloptindex]
             allopttime = aggtable["T_sgm(1.0)"][alloptindex]
+            alloptnrmtime = aggtable["NrmT_sgm(1.0)"][alloptindex]
+            alloptnodes = aggtable["N_sgm(100.0)"][alloptindex]
         else :
             alloptcount = 0
             allopttime = 0.0
+            alloptnrmtime = 0.0
+            alloptnodes = 0
+        if affindex in aggtable["_count_"] :
+            affcount = aggtable["_count_"][affindex]
+            affsolved = aggtable["_solved_"][affindex]
+            afftime = aggtable["T_sgm(1.0)"][affindex]
+            affnrmtime = aggtable["NrmT_sgm(1.0)"][affindex]
+            affnodes = aggtable["N_sgm(100.0)"][affindex]
+        else :
+            affcount = 0
+            affsolved = 0
+            afftime = 0.0
+            affnrmtime = 0.0
+            affnodes = 0
+
 
         # if we did not evaluate base only, then include also the numbers for base
         if comparehash is not None:
             basecleanindex = ("clean", basehash)
             baseallindex = ("all", basehash)
             basealloptindex = ("all-optimal", basehash)
+            baseaffindex = ("affected", basehash)
             basecommithash = basehash
             basecommittime = times[basehash]
             baseallcount = aggtable["_count_"][baseallindex]
             baseallsolved = aggtable["_solved_"][baseallindex]
             basealltime = aggtable["T_sgm(1.0)"][baseallindex]
+            baseallnrmtime = aggtable["NrmT_sgm(1.0)"][baseallindex]
+            baseallnodes = aggtable["N_sgm(100.0)"][baseallindex]
             basecleancount = aggtable["_count_"][basecleanindex]
             basecleansolved = aggtable["_solved_"][basecleanindex]
             basecleantime = aggtable["T_sgm(1.0)"][basecleanindex]
+            basecleannrmtime = aggtable["NrmT_sgm(1.0)"][basecleanindex]
+            basecleannodes = aggtable["N_sgm(100.0)"][basecleanindex]
             if basealloptindex in aggtable["_count_"] :
                 basealloptcount = aggtable["_count_"][basealloptindex]
                 baseallopttime = aggtable["T_sgm(1.0)"][basealloptindex]
+                basealloptnrmtime = aggtable["NrmT_sgm(1.0)"][basealloptindex]
+                basealloptnodes  = aggtable["N_sgm(100.0)"][basealloptindex]
             else :
                 basealloptcount = 0
                 baseallopttime = 0.0
+                basealloptnrmtime = 0.0
+                basealloptnodes = 0
+            if baseaffindex in aggtable["_count_"] :
+                baseaffcount = aggtable["_count_"][baseaffindex]
+                baseaffsolved = aggtable["_solved_"][baseaffindex]
+                baseafftime = aggtable["T_sgm(1.0)"][baseaffindex]
+                baseaffnrmtime = aggtable["NrmT_sgm(1.0)"][baseaffindex]
+                baseaffnodes  = aggtable["N_sgm(100.0)"][baseaffindex]
+            else :
+                baseaffcount = 0
+                baseaffsolved = 0
+                baseafftime = 0.0
+                baseaffnrmtime = 0.0
+                baseaffnodes = 0
         else:
             basecommithash = 0
             basecommittime = 0
             baseallcount = 0
             baseallsolved = 0
             basealltime = 0
+            baseallnrmtime = 0
+            baseallnodes = 0
             basecleancount = 0
             basecleansolved = 0
             basecleantime = 0
+            basecleannrmtime = 0
+            basecleannodes = 0
             basealloptcount = 0
             baseallopttime = 0
+            basealloptnrmtime = 0
+            basealloptnodes = 0
+            baseaffcount = 0
+            baseaffsolved = 0
+            baseafftime = 0
+            baseaffnrmtime = 0
+            baseaffnodes = 0
 
         self.write(
             ",".join(
@@ -171,21 +235,43 @@ class ComparisonEndpoint(BaseHandler):
                             allcount,
                             allsolved,
                             alltime,
+                            allnrmtime,
+                            allnodes,
                             cleancount,
                             cleansolved,
                             cleantime,
+                            cleannrmtime,
+                            cleannodes,
                             alloptcount,
                             allopttime,
+                            alloptnrmtime,
+                            alloptnodes,
+                            affcount,
+                            affsolved,
+                            afftime,
+                            affnrmtime,
+                            affnodes,
                             basecommithash,
                             basecommittime,
                             baseallcount,
                             baseallsolved,
                             basealltime,
+                            baseallnrmtime,
+                            baseallnodes,
                             basecleancount,
                             basecleansolved,
                             basecleantime,
+                            basecleannrmtime,
+                            basecleannodes,
                             basealloptcount,
-                            baseallopttime
+                            baseallopttime,
+                            basealloptnrmtime,
+                            basealloptnodes,
+                            baseaffcount,
+                            baseaffsolved,
+                            baseafftime,
+                            baseaffnrmtime,
+                            baseaffnodes
                         ],
                     )
                 )

--- a/rubberband/handlers/api/comparison.py
+++ b/rubberband/handlers/api/comparison.py
@@ -122,8 +122,12 @@ class ComparisonEndpoint(BaseHandler):
         cleancount = aggtable["_count_"][cleanindex]
         cleansolved = aggtable["_solved_"][cleanindex]
         cleantime = aggtable["T_sgm(1.0)"][cleanindex]
-        alloptcount = aggtable["_count_"][alloptindex]
-        allopttime = aggtable["T_sgm(1.0)"][alloptindex]
+        if alloptindex in aggtable["_count_"] :
+            alloptcount = aggtable["_count_"][alloptindex]
+            allopttime = aggtable["T_sgm(1.0)"][alloptindex]
+        else :
+            alloptcount = 0
+            allopttime = 0.0
 
         # if we did not evaluate base only, then include also the numbers for base
         if comparehash is not None:
@@ -138,8 +142,12 @@ class ComparisonEndpoint(BaseHandler):
             basecleancount = aggtable["_count_"][basecleanindex]
             basecleansolved = aggtable["_solved_"][basecleanindex]
             basecleantime = aggtable["T_sgm(1.0)"][basecleanindex]
-            basealloptcount = aggtable["_count_"][basealloptindex]
-            baseallopttime = aggtable["T_sgm(1.0)"][basealloptindex]
+            if basealloptindex in aggtable["_count_"] :
+                basealloptcount = aggtable["_count_"][basealloptindex]
+                baseallopttime = aggtable["T_sgm(1.0)"][basealloptindex]
+            else :
+                basealloptcount = 0
+                baseallopttime = 0.0
         else:
             basecommithash = 0
             basecommittime = 0

--- a/rubberband/static/js/results-detail.js
+++ b/rubberband/static/js/results-detail.js
@@ -13,6 +13,7 @@ var modal = document.getElementById("info-modal");
 var ipetlongtable;
 var ipetaggtable;
 var detailstable;
+var detailsperftable;
 
 // ####################################### functions
 function format_dt_searchfield(tableident) {
@@ -199,7 +200,7 @@ function initSimpleTable(tableident) {
 
 function initDetailsTable(tablename) {
   var tableident = "#"+tablename;
-  detailstable = $(tableident).DataTable({
+  var table = $(tableident).DataTable({
     scrollY: '80vh', scrollX: true, scroller: true, scrollCollapse: true,
     paging: false,
     columnDefs: [
@@ -217,13 +218,15 @@ function initDetailsTable(tablename) {
   construct_columns_toggle(tablename);
   /* we need to do this for tables with fixed columns by hand */
   $(document).on('mouseenter mouseleave', 'table#'+tablename+' tbody tr', hoverTable(1, tablename));
+  
+  return table;
 }
 
 /*
  * Colorate the details table cells for the compare view
  */
-function colorateCells() {
-  detailstable.cells().every( function () {
+function colorateCells(table) {
+  table.cells().every( function () {
     // determine if tooltip is string or number
     var element = $(this.node())[0];
     if (element.attributes["title"] !== undefined) {
@@ -449,10 +452,11 @@ function construct_row_toggle(toggleident) {
 
 $(document).ready(function(){
   /* init datatables */
-  initDetailsTable('details-table');
+  detailstable = initDetailsTable('details-table');
+  detailsperftable = initDetailsTable('details-perf-table');
 
   // if compare is in query string, then we are in the compare view
-  if (window.location.search.indexOf("compare") >= 0) { colorateCells(); }
+  if (window.location.search.indexOf("compare") >= 0) { colorateCells(detailstable); colorateCells(detailsperftable); }
 
   initSimpleTable('.meta-table, #settings-table');
   format_dt_searchfield(".dataTables");

--- a/rubberband/templates/results/details_perf_table.html
+++ b/rubberband/templates/results/details_perf_table.html
@@ -1,0 +1,65 @@
+{% set cols = [
+  {"name": "Status", "short": "Status", "type": "text", "key": "Status"},
+  {"name": "Solving Time", "short": "Time", "type": "number", "key": "SolvingTime"},
+  {"name": "Norm Time", "short": "NTime", "type": "number", "key": "NormalizedTime"},
+  {"name": "Norm Freq", "short": "NFreq", "type": "number", "key": "NormalizedFreq"},
+  {"name": "Task Clock", "short": "TaskClock", "type": "number", "key": "perf:task-clock"},
+  {"name": "Instructions U", "short": "InstrU", "type": "number", "key": "perf:instructions:u"},
+  {"name": "Instructions K", "short": "InstrK", "type": "number", "key": "perf:instructions:k"},
+  {"name": "CPU Cycles U", "short": "CyclesU", "type": "number", "key": "perf:cpu-cycles:u"},
+  {"name": "CPU Cycles K", "short": "CyclesK", "type": "number", "key": "perf:cpu-cycles:k"},
+  {"name": "Cache Refs", "short": "CacheRef", "type": "number", "key": "perf:cache-references:u"},
+  {"name": "Cache Misses", "short": "CacheMiss", "type": "number", "key": "perf:cache-misses:u"},
+  {"name": "Branch Instr U", "short": "BranchInstrU", "type": "number", "key": "perf:branch-instructions:u"},
+  {"name": "Branch Misses U", "short": "BranchMissU", "type": "number", "key": "perf:branch-misses:u"},
+  {"name": "Minor Faults U", "short": "MinorFaultU", "type": "number", "key": "perf:minor-faults:u"},
+  {"name": "Minor Faults K", "short": "MinorFaultU", "type": "number", "key": "perf:minor-faults:k"},
+  {"name": "Major Faults U", "short": "MajorFaultU", "type": "number", "key": "perf:major-faults:u"},
+  {"name": "Major Faults K", "short": "MajorFaultU", "type": "number", "key": "perf:major-faults:k"},
+  {"name": "Context Switches", "short": "ContextSwitch", "type": "number", "key": "perf:context-switches"},
+  {"name": "Cycles Mem Any", "short": "CycleMemAny", "type": "number", "key": "perf:cycle-activity-cycles-mem-any"},
+  {"name": "Stalls Mem Any", "short": "StallsMemAny", "type": "number", "key": "perf:cycle-activity-stalls-mem-any"},
+  {"name": "Stalls Total", "short": "StallsTotal", "type": "number", "key": "perf:cycle-activity-stalls-total"},
+  ] %}
+<table id="details-perf-table" class="{{rb_dt_compact}} {{rb_dt_borderless}} rb-table rb-table-data" width="100%">
+  <thead>
+    <tr>
+    <th class="text">{% raw shortening_span("Instance Name", "Inst") %}</th>
+    {% for i in cols %}
+      <th class="{{ i["type"] }}">{% raw shortening_span(i["short"], i["short"]) %}</th>
+    {% end %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for name, r in file.results.to_dict().items() %}
+    {% if not compare or name in sets["intersection"] %}
+    <tr>
+
+      {% if compare %}
+        <td>
+          {% set href="/instance/{rid}?compare={compare}".format(rid=r.meta.id, compare=','.join([c.meta.id for c in compare])) %}
+          {% raw get_link(href, r.instance_name, 20, 7) %}
+        </td>
+      {% else %}
+        <td>
+          {% set href="/instance/{rid}".format(rid=r.meta.id, compare=','.join([c.meta.id for c in compare])) %}
+          {% raw get_link(href, r.instance_name, 20, 7) %}
+        </td>
+      {% end %}
+
+      {% for i in cols %}
+
+          {% if compare %}
+            <td title="{{ format_attrs(compare, i["key"], name) }}" class="{{ format_type(r, i["key"]) }} {{ i["key"] }}">{{ format_attr(r, i["key"]) }}</td>
+          {% else %}
+            <td class="{{ format_type(r, i["key"]) }}">{{ format_attr(r, i["key"]) }}</td>
+          {% end %}
+
+      {% end %}
+
+    </tr>
+    {% end %}
+    {% end %}
+  </tbody>
+</table>
+

--- a/rubberband/templates/results/details_table.html
+++ b/rubberband/templates/results/details_table.html
@@ -17,6 +17,7 @@
   {"name": "Nodes", "short": "Nodes", "type": "number"},
   {"name": "Solving Time", "short": "Time", "type": "number"},
   {"name": "Total Time", "short": "TTime", "type": "number"},
+  {"name": "Norm Time", "short": "NTime", "type": "number"},
   ] %}
 <table id="details-table" class="{{rb_dt_compact}} {{rb_dt_borderless}} rb-table rb-table-data" width="100%">
   <thead>
@@ -45,7 +46,7 @@
 
       {% set objsen = get_objsen(compare + [file], name) %}
 
-      {% for i in ["instance_type", "OriginalProblem_InitialNCons", "OriginalProblem_Vars", "PresolvedProblem_InitialNCons", "PresolvedProblem_Vars", "DualBound", "PrimalBound", "Gap", "Iterations", "Nodes", "TotalTime_solving", "SolvingTime"] %}
+      {% for i in ["instance_type", "OriginalProblem_InitialNCons", "OriginalProblem_Vars", "PresolvedProblem_InitialNCons", "PresolvedProblem_Vars", "DualBound", "PrimalBound", "Gap", "Iterations", "Nodes", "TotalTime_solving", "SolvingTime", "NormalizedTime"] %}
 
         {% if compare %}
           <td title="{{ format_attrs(compare, i, name) }}"{% if (i == "DualBound" and objsen > 0) or (i == "PrimalBound" and objsen < 0) %} invert="yes"{% end %} class="{{ format_type(r, i) }} {{ i }}"{% if (i == "DualBound") %} compare="{{ format_attrs(compare + [file], "PrimalBound", name) }}"{% end %}{% if (i == "PrimalBound") %} compare="{{ format_attrs(compare + [file], "DualBound", name) }}"{% end %}>{{ format_attr(r, i) }}</td>

--- a/rubberband/templates/results/details_table.html
+++ b/rubberband/templates/results/details_table.html
@@ -1,28 +1,23 @@
-{% if file.solver == "GENIOS" %}
-{% set add_cols = [{"name": "Status", "short": "Stat", "type": "text"}] %}
-{% else %}
-{% set add_cols = [{"name": "Status", "short": "Stat", "type": "text"}] %}
-{% end %}
 {% set cols = [
-  {"name": "Instance Name", "short": "Inst", "type": "text"},
-  {"name": "Type", "short": "Type", "type": "text"},
-  {"name": "Original Cons", "short": "OCons", "type": "number"},
-  {"name": "Original Vars", "short": "OVars", "type": "number"},
-  {"name": "Presolved Cons", "short": "PCons", "type": "number"},
-  {"name": "Presolved Vars", "short": "PVars", "type": "number"},
-  {"name": "Dual Bound", "short": "DB", "type": "number"},
-  {"name": "Primal Bound", "short": "PB", "type": "number"},
-  {"name": "Gap", "short": "Gap", "type": "number"},
-  {"name": "Iterations", "short": "Iter", "type": "number"},
-  {"name": "Nodes", "short": "Nodes", "type": "number"},
-  {"name": "Solving Time", "short": "Time", "type": "number"},
-  {"name": "Total Time", "short": "TTime", "type": "number"},
-  {"name": "Norm Time", "short": "NTime", "type": "number"},
+  {"name": "Status", "short": "Stat", "type": "text", "key": "Status"},
+  {"name": "Nodes", "short": "Nodes", "type": "number", "key": "Nodes"},
+  {"name": "Solving Time", "short": "Time", "type": "number", "key": "SolvingTime"},
+  {"name": "Norm Time", "short": "NTime", "type": "number", "key": "NormalizedTime"},
+  {"name": "Iterations", "short": "Iter", "type": "number", "key": "Iterations"},
+  {"name": "Gap", "short": "Gap", "type": "number", "key": "Gap"},
+  {"name": "Dual Bound", "short": "DB", "type": "number", "key": "DualBound"},
+  {"name": "Primal Bound", "short": "PB", "type": "number", "key": "PrimalBound"},
+  {"name": "Total Time", "short": "TTime", "type": "number", "key": "TotalTime_solving"},
+  {"name": "Original Cons", "short": "OCons", "type": "number", "key": "OriginalProblem_InitialNCons"},
+  {"name": "Original Vars", "short": "OVars", "type": "number", "key": "OriginalProblem_Vars"},
+  {"name": "Presolved Cons", "short": "PCons", "type": "number", "key": "PresolvedProblem_InitialNCons"},
+  {"name": "Presolved Vars", "short": "PVars", "type": "number", "key": "PresolvedProblem_Vars"},
   ] %}
 <table id="details-table" class="{{rb_dt_compact}} {{rb_dt_borderless}} rb-table rb-table-data" width="100%">
   <thead>
     <tr>
-    {% for i in cols + add_cols %}
+    <th class="text">{% raw shortening_span("Instance Name", "Inst") %}</th>
+    {% for i in cols %}
       <th class="{{ i["type"] }}">{% raw shortening_span(i["name"], i["short"]) %}</th>
     {% end %}
     </tr>
@@ -46,22 +41,12 @@
 
       {% set objsen = get_objsen(compare + [file], name) %}
 
-      {% for i in ["instance_type", "OriginalProblem_InitialNCons", "OriginalProblem_Vars", "PresolvedProblem_InitialNCons", "PresolvedProblem_Vars", "DualBound", "PrimalBound", "Gap", "Iterations", "Nodes", "TotalTime_solving", "SolvingTime", "NormalizedTime"] %}
+      {% for i in cols %}
 
         {% if compare %}
-          <td title="{{ format_attrs(compare, i, name) }}"{% if (i == "DualBound" and objsen > 0) or (i == "PrimalBound" and objsen < 0) %} invert="yes"{% end %} class="{{ format_type(r, i) }} {{ i }}"{% if (i == "DualBound") %} compare="{{ format_attrs(compare + [file], "PrimalBound", name) }}"{% end %}{% if (i == "PrimalBound") %} compare="{{ format_attrs(compare + [file], "DualBound", name) }}"{% end %}>{{ format_attr(r, i) }}</td>
+          <td title="{{ format_attrs(compare, i["key"], name) }}"{% if (i["key"] == "DualBound" and objsen > 0) or (i["key"] == "PrimalBound" and objsen < 0) %} invert="yes"{% end %} class="{{ format_type(r, i["key"]) }} {{ i["key"] }}"{% if (i["key"] == "DualBound") %} compare="{{ format_attrs(compare + [file], "PrimalBound", name) }}"{% end %}{% if (i["key"] == "PrimalBound") %} compare="{{ format_attrs(compare + [file], "DualBound", name) }}"{% end %}>{{ format_attr(r, i["key"]) }}</td>
         {% else %}
-          <td class="{{ format_type(r, i) }}">{{ format_attr(r, i) }}</td>
-        {% end %}
-
-      {% end %}
-
-      {% for i in add_cols %}
-
-        {% if compare %}
-          <td title="{{ format_attrs(compare, i["name"], name) }}" class="{{ format_type(r, i["name"]) }} {{ i["name"] }}">{{ format_attr(r, i["name"]) }}</td>
-        {% else %}
-          <td class="{{ format_type(r, i["name"]) }}">{{ format_attr(r, i["name"]) }}</td>
+          <td class="{{ format_type(r, i["key"]) }}">{{ format_attr(r, i["key"]) }}</td>
         {% end %}
 
       {% end %}

--- a/rubberband/templates/results/res_view_details.html
+++ b/rubberband/templates/results/res_view_details.html
@@ -45,8 +45,9 @@
     </div>
   {% end %}
 
-  <h2 class="rb-details-tab-title">Detailed perf data</h2>
-  <div class="datatables-content">
+  <h2 class="rb-collapser" href="#details-perf-table-div" data-toggle="collapse" role="button">Detailed perf data
+    <span class="fa fa-angle-down small float-right p-2"></span></h2>
+  <div class="collapse" id="details-perf-table-div">
     {% include "details_perf_table.html" %}
   </div>
 

--- a/rubberband/templates/results/res_view_details.html
+++ b/rubberband/templates/results/res_view_details.html
@@ -45,6 +45,11 @@
     </div>
   {% end %}
 
+  <h2 class="rb-details-tab-title">Detailed perf data</h2>
+  <div class="datatables-content">
+    {% include "details_perf_table.html" %}
+  </div>
+
   <!-- Modals =========================================== -->
   {% if not compare %}
 

--- a/staticfiles/xml/eval_groupgithash_exclude.xml
+++ b/staticfiles/xml/eval_groupgithash_exclude.xml
@@ -10,6 +10,9 @@
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="shmean shift. by 100">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column  formatstr="%.1f" name="PDI" transformfunc="min" comp="quot" reduction="mean">
       <Column origcolname="InternalPrimalDualIntegral" />
       <Column origcolname="PrimalDualIntegral" />

--- a/staticfiles/xml/eval_groupgithash_exclude_detailed.xml
+++ b/staticfiles/xml/eval_groupgithash_exclude_detailed.xml
@@ -4,6 +4,9 @@
     <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="shmean shift. by 100">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/eval_grouplpsolver_exclude.xml
+++ b/staticfiles/xml/eval_grouplpsolver_exclude.xml
@@ -7,6 +7,9 @@
     <Column formatstr="%.2f" name="maxT" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="max">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="shmean shift. by 100">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/eval_groupsettings_exclude.xml
+++ b/staticfiles/xml/eval_groupsettings_exclude.xml
@@ -7,6 +7,9 @@
     <Column formatstr="%.2f" name="maxT" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="max">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="shmean shift. by 100">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/eval_groupsettings_exclude_detailed.xml
+++ b/staticfiles/xml/eval_groupsettings_exclude_detailed.xml
@@ -4,6 +4,9 @@
     <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="shmean shift. by 100">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/eval_groupsettings_include_detailed.xml
+++ b/staticfiles/xml/eval_groupsettings_include_detailed.xml
@@ -7,6 +7,9 @@
     <Column formatstr="%.2f" name="maxT" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="max">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="shmean shift. by 100">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/eval_singleruns_exclude.xml
+++ b/staticfiles/xml/eval_singleruns_exclude.xml
@@ -4,6 +4,9 @@
     <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="mean">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="mean">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="mean">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/eval_singleruns_include.xml
+++ b/staticfiles/xml/eval_singleruns_include.xml
@@ -4,6 +4,9 @@
     <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="mean">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="mean">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="mean">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/eval_singleruns_punish.xml
+++ b/staticfiles/xml/eval_singleruns_punish.xml
@@ -5,6 +5,10 @@
         <Filter anytestrun="one" expression1="_fail_" expression2="1" operator="eq"/>
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="mean">
+        <Filter anytestrun="one" expression1="_fail_" expression2="1" operator="eq"/>
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
     <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="mean">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>

--- a/staticfiles/xml/evalperf_groupgithash_exclude_detailed.xml
+++ b/staticfiles/xml/evalperf_groupgithash_exclude_detailed.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" ?>
+<!-- group by githash - exclude fails & aborts, perf statistics -->
+<Evaluation comparecolformat="%.3f" index="ProblemName Seed Permutation GitHash" indexsplit="3">
+    <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
+    <Column name="St" origcolname="Status"/>
+    <Column origcolname="perf:cpu-cycles:u" minval="1" name="CyclesU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cpu-cycles:k" minval="1" name="CyclesK" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:instructions:u" minval="1" name="InstrU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:instructions:k" minval="1" name="InstrK" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cache-references:u" minval="1" name="CacheRefU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cache-misses:u" minval="1" name="CacheMissU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:branch-instructions:u" minval="1" name="BranchInstrU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:branch-misses:u" minval="1" name="BranchMissU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:minor-faults:u" minval="0" name="MinorFaultU">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:minor-faults:k" minval="0" name="MinorFaultK">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:major-faults:u" minval="0" name="MajorFaultU">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:major-faults:k" minval="0" name="MajorFaultK">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:context-switches" minval="0" name="ContextSwitch">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:cycle-activity-cycles-mem-any" minval="1" name="CycleMemAny" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cycle-activity-stalls-mem-any" minval="1" name="StallMemAny" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cycle-activity-stalls-total" minval="1" name="StallTotal" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:task-clock" minval="1" name="TaskClock">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <FilterGroup name="all"/>
+    <FilterGroup name="clean">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="affected">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="one" datakey="LP_Iterations_dualLP" operator="diff"/>
+        <Filter active="True" anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="unaffected">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="all" datakey="LP_Iterations_dualLP" operator="equal"/>
+    </FilterGroup>
+    <FilterGroup name="[0,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup name="[1,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="1" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[10,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="10" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[100,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="100" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[1000,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="1000" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[0,10)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="all" expression1="T" expression2="10" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup name="[0,100)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="all" expression1="T" expression2="100" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup name="all-optimal">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_solved_" expression2="1" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup name="diff-timeouts">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="0" operator="eq"/>
+    </FilterGroup>
+</Evaluation>

--- a/staticfiles/xml/evalperf_groupsettings_exclude_detailed.xml
+++ b/staticfiles/xml/evalperf_groupsettings_exclude_detailed.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" ?>
+<!-- group by settings - exclude fails & aborts - detailed, perf statistics -->
+<Evaluation comparecolformat="%.3f" index="ProblemName Seed Permutation Settings" indexsplit="3">
+    <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="shmean shift. by 1">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
+    <Column name="St" origcolname="Status"/>
+    <Column origcolname="perf:cpu-cycles:u" minval="1" name="CyclesU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cpu-cycles:k" minval="1" name="CyclesK" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:instructions:u" minval="1" name="InstrU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:instructions:k" minval="1" name="InstrK" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cache-references:u" minval="1" name="CacheRefU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cache-misses:u" minval="1" name="CacheMissU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:branch-instructions:u" minval="1" name="BranchInstrU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:branch-misses:u" minval="1" name="BranchMissU" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:minor-faults:u" minval="0" name="MinorFaultU">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:minor-faults:k" minval="0" name="MinorFaultK">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:major-faults:u" minval="0" name="MajorFaultU">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:major-faults:k" minval="0" name="MajorFaultK">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:context-switches" minval="0" name="ContextSwitch">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <Column origcolname="perf:cycle-activity-cycles-mem-any" minval="1" name="CycleMemAny" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cycle-activity-stalls-mem-any" minval="1" name="StallMemAny" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:cycle-activity-stalls-total" minval="1" name="StallTotal" comp="quot shift. by 1000">
+        <Aggregation aggregation="shmean" name="shmean" shiftby="1000.0"/>
+    </Column>
+    <Column origcolname="perf:task-clock" minval="1" name="TaskClock">
+        <Aggregation aggregation="mean" name="mean"/>
+    </Column>
+    <FilterGroup name="all"/>
+    <FilterGroup name="clean">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="affected">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="one" datakey="LP_Iterations_dualLP" operator="diff"/>
+        <Filter active="True" anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="unaffected">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="all" datakey="LP_Iterations_dualLP" operator="equal"/>
+    </FilterGroup>
+    <FilterGroup name="[0,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup name="[1,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="1" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[10,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="10" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[100,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="100" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[1000,tilim]">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="T" expression2="1000" operator="ge"/>
+    </FilterGroup>
+    <FilterGroup name="[0,10)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="all" expression1="T" expression2="10" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup name="[0,100)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="all" expression1="T" expression2="100" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup name="all-optimal">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_solved_" expression2="1" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup name="diff-timeouts">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="0" operator="eq"/>
+    </FilterGroup>
+</Evaluation>


### PR DESCRIPTION
- in comparison API call, return also normalized time and nodes and data for subset of affected instances
- fix comparison API call to handle case where `all-optimal` set is empty (e.g., all instances timeout).
- add a second "Detailed Data" table with statistics collected by perf
- reorganize "Detailed Data" columns to put useful data front, drop type
- add additional evaluations that compare perf statistics
- add normalized time to already existing evaluations
