### PR TITLE
feat: "Open in LogAnalyzer" hand-off from result/comparison view

### DIFF
--- a/config/app.cfg
+++ b/config/app.cfg
@@ -47,3 +47,12 @@ smtp_from_address = "someusername@gmail.com"
 smtp_username = "someusername"
 # SMTP authentication paassword
 smtp_password = "STMPSECRETPASS"
+
+# LogAnalyzer integration. Enables an "Open in LogAnalyzer" button on the
+# result/comparison view that hands the run's raw logs to a LogAnalyzer instance.
+# loganalyzer_url is the internal address Rubberband uploads to (server-to-server,
+# should bypass the auth proxy); loganalyzer_public_url is the browser-facing
+# address used for the redirect (set it when LogAnalyzer is behind a reverse
+# proxy on a different host/path). Leave loganalyzer_url empty to disable.
+loganalyzer_url = "http://127.0.0.1:7831"
+loganalyzer_public_url = "https://loganalyzer.example.com"

--- a/rubberband/boilerplate.py
+++ b/rubberband/boilerplate.py
@@ -74,8 +74,15 @@ define("smtp_password", default="", help="The password for SMTP authentication."
 define(
     "loganalyzer_url",
     default="",
-    help="Base URL of a LogAnalyzer instance to hand runs off to for analysis. "
-    "When empty, the 'Open in LogAnalyzer' button is hidden.",
+    help="Internal base URL of a LogAnalyzer instance that Rubberband uploads runs "
+    "to (server-to-server). When empty, the 'Open in LogAnalyzer' button is hidden.",
+)
+define(
+    "loganalyzer_public_url",
+    default="",
+    help="Browser-facing base URL of LogAnalyzer used for the redirect after upload. "
+    "Set this when LogAnalyzer is behind a reverse proxy on a different host/path "
+    "than loganalyzer_url. Falls back to loganalyzer_url when empty.",
 )
 
 

--- a/rubberband/boilerplate.py
+++ b/rubberband/boilerplate.py
@@ -71,6 +71,13 @@ define(
 define("smtp_username", default="", help="The username for SMTP authentication.")
 define("smtp_password", default="", help="The password for SMTP authentication.")
 
+define(
+    "loganalyzer_url",
+    default="",
+    help="Base URL of a LogAnalyzer instance to hand runs off to for analysis. "
+    "When empty, the 'Open in LogAnalyzer' button is hidden.",
+)
+
 
 def make_app(project_root):
     """

--- a/rubberband/boilerplate.py
+++ b/rubberband/boilerplate.py
@@ -73,13 +73,13 @@ define("smtp_password", default="", help="The password for SMTP authentication."
 
 define(
     "loganalyzer_url",
-    default="",
+    default="http://127.0.0.1:7831/loganalyzer",
     help="Internal base URL of a LogAnalyzer instance that Rubberband uploads runs "
     "to (server-to-server). When empty, the 'Open in LogAnalyzer' button is hidden.",
 )
 define(
     "loganalyzer_public_url",
-    default="",
+    default="http://127.0.0.1:8080/loganalyzer",
     help="Browser-facing base URL of LogAnalyzer used for the redirect after upload. "
     "Set this when LogAnalyzer is behind a reverse proxy on a different host/path "
     "than loganalyzer_url. Falls back to loganalyzer_url when empty.",
@@ -117,6 +117,15 @@ def make_app(project_root):
         options.parse_config_file(config)
     else:
         logging.info("Using default config.")
+
+    # Override options from RUBBERBAND_<UPPER_CASE_NAME> environment variables.
+    # Highest priority: env var > config file > code defaults.
+    for name in options:
+        env_key = "RUBBERBAND_{}".format(name.upper())
+        env_val = os.environ.get(env_key)
+        if env_val is not None:
+            logging.info("Overriding %s from env var %s", name, env_key)
+            setattr(options, name, env_val)
 
     # settings for tornado
     settings = {

--- a/rubberband/handlers/fe/__init__.py
+++ b/rubberband/handlers/fe/__init__.py
@@ -11,6 +11,7 @@ from .main import MainView  # noqa
 from .search import SearchView  # noqa
 from .upload import UploadView  # noqa
 from .download import DownloadView  # noqa
+from .analyze import AnalyzeExternalView  # noqa
 from .visualize import VisualizeView  # noqa
 from .evaluation import EvaluationView  # noqa
 from .display import DisplayView  # noqa

--- a/rubberband/handlers/fe/analyze.py
+++ b/rubberband/handlers/fe/analyze.py
@@ -69,7 +69,10 @@ class AnalyzeExternalView(BaseHandler):
         testsets : str
             comma-separated TestSet ids
         """
+        # internal URL for the server-to-server upload; public URL for the
+        # browser redirect (behind a reverse proxy these differ)
         base = options.loganalyzer_url.rstrip("/")
+        public_base = (options.loganalyzer_public_url or options.loganalyzer_url).rstrip("/")
         if not base:
             raise HTTPError(404, reason="LogAnalyzer integration is not configured.")
 
@@ -131,8 +134,8 @@ class AnalyzeExternalView(BaseHandler):
         # poll until the runs complete and then create the comparison via
         # /api/compare, redirecting straight to /comparison-instances/<id>.)
         if payload.get("run_id"):
-            self.redirect("{}/instances/{}".format(base, payload["run_id"]))
+            self.redirect("{}/instances/{}".format(public_base, payload["run_id"]))
         elif payload.get("runs"):
-            self.redirect("{}/".format(base))
+            self.redirect("{}/".format(public_base))
         else:
             raise HTTPError(502, reason="Unexpected response from LogAnalyzer.")

--- a/rubberband/handlers/fe/analyze.py
+++ b/rubberband/handlers/fe/analyze.py
@@ -1,0 +1,138 @@
+"""Contains AnalyzeExternalView: hand a run/comparison off to LogAnalyzer."""
+
+import os
+import json
+import uuid
+import zipfile
+from io import BytesIO
+
+from tornado.web import HTTPError
+from tornado.options import options
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+
+from .base import BaseHandler
+from .result import load_testsets
+from rubberband.constants import EXPORT_FILE_TYPES
+
+
+def _encode_multipart(fields, files):
+    """
+    Encode form fields and files as multipart/form-data.
+
+    Parameters
+    ----------
+    fields : dict
+        name -> string value
+    files : list of tuple
+        (field_name, filename, content_type, bytes)
+
+    Returns
+    -------
+    (bytes, str)
+        the encoded body and the matching Content-Type header value
+    """
+    boundary = uuid.uuid4().hex
+    marker = ("--" + boundary).encode()
+    lines = []
+    for name, value in fields.items():
+        lines += [
+            marker,
+            'Content-Disposition: form-data; name="{}"'.format(name).encode(),
+            b"",
+            value.encode(),
+        ]
+    for name, filename, content_type, data in files:
+        lines += [
+            marker,
+            'Content-Disposition: form-data; name="{}"; filename="{}"'.format(
+                name, filename
+            ).encode(),
+            "Content-Type: {}".format(content_type).encode(),
+            b"",
+            data,
+        ]
+    lines += [("--" + boundary + "--").encode(), b""]
+    body = b"\r\n".join(lines)
+    return body, "multipart/form-data; boundary={}".format(boundary)
+
+
+class AnalyzeExternalView(BaseHandler):
+    """Bundle one or more TestSets and hand them to a LogAnalyzer instance."""
+
+    async def get(self, testsets):
+        """
+        Zip the raw logs of the given testsets, upload them to LogAnalyzer and
+        redirect the user to the resulting LogAnalyzer run page.
+
+        Parameters
+        ----------
+        testsets : str
+            comma-separated TestSet ids
+        """
+        base = options.loganalyzer_url.rstrip("/")
+        if not base:
+            raise HTTPError(404, reason="LogAnalyzer integration is not configured.")
+
+        ts_ids = [t for t in testsets.split(",") if t]
+        if not ts_ids:
+            raise HTTPError(400, reason="No testsets given.")
+        ts_list = load_testsets(ts_ids)
+
+        # Build the same raw-log archive the download button produces. LogAnalyzer
+        # detects the Rubberband filename convention and re-parses with its own
+        # parser, so we hand over the raw logs, not Rubberband's parsed data.
+        with BytesIO() as byteio:
+            with zipfile.ZipFile(byteio, "w", zipfile.ZIP_DEFLATED) as archive:
+                for ts in ts_list:
+                    for ftype in EXPORT_FILE_TYPES:
+                        try:
+                            archive.writestr(
+                                "{}/{}{}".format(
+                                    ts.meta.id,
+                                    os.path.splitext(ts.filename)[0],
+                                    ftype,
+                                ),
+                                ts.raw(ftype),
+                            )
+                        except TypeError:
+                            # ts.raw() returned None for a missing file type
+                            pass
+            zip_bytes = byteio.getvalue()
+
+        label = (", ".join(ts.filename for ts in ts_list))[:120] or "Rubberband run"
+        body, content_type = _encode_multipart(
+            fields={"name": label, "description": "Imported from Rubberband"},
+            files=[("files", "rubberband.zip", "application/zip", zip_bytes)],
+        )
+
+        request = HTTPRequest(
+            url="{}/api/upload".format(base),
+            method="POST",
+            body=body,
+            headers={"Content-Type": content_type},
+            request_timeout=180,
+        )
+        try:
+            response = await AsyncHTTPClient().fetch(request)
+        except Exception as e:  # noqa: BLE001 - surface any transport/HTTP error
+            raise HTTPError(502, reason="Could not reach LogAnalyzer: {}".format(e))
+
+        try:
+            payload = json.loads(response.body)
+        except ValueError:
+            raise HTTPError(502, reason="Unexpected response from LogAnalyzer.")
+
+        # A single run lands directly on its instances page. When LogAnalyzer
+        # splits a Rubberband comparison into several runs (it groups by setting),
+        # it returns {"multiple_runs": true, "runs": [...]} with no top-level
+        # run_id; the runs still need to finish processing before they can be
+        # compared, so we drop the user on LogAnalyzer's dashboard where the
+        # freshly-created runs appear and can be compared. (A future step could
+        # poll until the runs complete and then create the comparison via
+        # /api/compare, redirecting straight to /comparison-instances/<id>.)
+        if payload.get("run_id"):
+            self.redirect("{}/instances/{}".format(base, payload["run_id"]))
+        elif payload.get("runs"):
+            self.redirect("{}/".format(base))
+        else:
+            raise HTTPError(502, reason="Unexpected response from LogAnalyzer.")

--- a/rubberband/handlers/fe/base.py
+++ b/rubberband/handlers/fe/base.py
@@ -73,6 +73,17 @@ class BaseHandler(RequestHandler):
         """
         return self.request.protocol + "://" + self.request.host
 
+    def get_loganalyzer_url(self):
+        """
+        Base URL of the configured LogAnalyzer instance, or an empty string.
+
+        Returns
+        -------
+        str
+            the LogAnalyzer url ("" disables the integration)
+        """
+        return options.loganalyzer_url
+
     def get_rb_url(self):
         """
         Url where the rubberband instance lives.

--- a/rubberband/routes.py
+++ b/rubberband/routes.py
@@ -10,6 +10,7 @@ routes = [
     (r"/compare", fe.CompareView),
     (r"/display/(?P<mode>[^\/]+)/(?P<id>[^\/]+)", fe.DisplayView),
     (r"/download?(?P<arg>[^\/]+)", fe.DownloadView),
+    (r"/analyze/(?P<testsets>[^\/]+)", fe.AnalyzeExternalView),
     (r"/eval/(?P<eval_id>[^\/]+)", fe.EvaluationView),
     (r"/file/(?P<file_id>[^\/]+)", fe.FileView),
     (r"/help", fe.HelpView),

--- a/rubberband/templates/result_view.html
+++ b/rubberband/templates/result_view.html
@@ -29,7 +29,7 @@
 
     {% if handler.get_loganalyzer_url() %}
     <a class="bs-tooltip ml-2 mr-2" data-toggle="tooltip" data-placement="top" href="/analyze/{{ ','.join([file.meta.id] + [c.meta.id for c in compare]) }}" title="open in LogAnalyzer" target="_blank">
-      <span class="fa fa-external-link"></span></a>
+      <span class="fa fa-chart-bar"></span></a>
     {% end %}
 
   </div>

--- a/rubberband/templates/result_view.html
+++ b/rubberband/templates/result_view.html
@@ -27,6 +27,11 @@
       <span class="fa fa-gift"></span></a>
     {% end %}
 
+    {% if handler.get_loganalyzer_url() %}
+    <a class="bs-tooltip ml-2 mr-2" data-toggle="tooltip" data-placement="top" href="/analyze/{{ ','.join([file.meta.id] + [c.meta.id for c in compare]) }}" title="open in LogAnalyzer" target="_blank">
+      <span class="fa fa-external-link"></span></a>
+    {% end %}
+
   </div>
 
   <h2 data-toggle="collapse" href="#rb-legend" role="button" class="rb-details-tab-title rb-collapser">Testrun{% if compare %}s{% end %} <span class="fa fa-angle-down small"></span></h2>


### PR DESCRIPTION
Adds an "Open in LogAnalyzer" button on the result/comparison view that hands
the run's raw solver logs (same zip as the download button) to a LogAnalyzer
instance for richer comparison UIs.
