### PR TITLE
Add simplified evaluation xml

### DIFF
--- a/rubberband/handlers/fe/evaluation.py
+++ b/rubberband/handlers/fe/evaluation.py
@@ -82,6 +82,10 @@ class EvaluationView(BaseHandler):
         # do evaluation
         longtable, aggtable = ev.evaluate(ex)
 
+        # ipet only applies the evaluation's suppressions when it streams a table
+        # to a file, so drop the suppressed columns here as well
+        aggtable = ev.suppressColumns(aggtable)
+
         # None style is default
         if style is None:
             # add filtergroup buttons to ipet long table

--- a/staticfiles/xml/eval_singleruns_solved.xml
+++ b/staticfiles/xml/eval_singleruns_solved.xml
@@ -1,172 +1,524 @@
-"""Define constants used by rubberband."""
-
-INFINITY_KEYS = (
-    "separating/flowcover/maxslackroot",
-    "separating/flowcover/maxslack",
-    "heuristics/undercover/maxcoversizeconss",
-    "solvingphases/optimalvalue",
-    "misc/referencevalue",
-)
-INFINITY_MASK = -1
-INFINITY_FLOAT = float("inf")
-INFINITY_DISPLAY = 1e20
-FILE_INDEX = "file"
-RESULT_INDEX = "result"
-TESTSET_INDEX = "testset"
-SETTINGS_INDEX = "settings"
-ZIPPED_SUFFIX = ".gz"
-FILES_DIR = "staticfiles/"
-SOLU_DIR = FILES_DIR + "instancedata/"
-STATIC_FILES_DIR = FILES_DIR + "xml/"
-ADD_READERS = STATIC_FILES_DIR + "additional_readers.xml"
-IPET_EVALUATIONS = {
-    0: {
-        "path": STATIC_FILES_DIR + "eval_groupgithash_exclude_detailed.xml",
-        "name": "detailed view - group githash, exclude",
-    },
-    1: {
-        "path": STATIC_FILES_DIR + "eval_groupsettings_exclude_detailed.xml",
-        "name": "detailed view - group settings, exclude",
-    },
-    2: {
-        "path": STATIC_FILES_DIR + "eval_groupsettings_include_detailed.xml",
-        "name": "detailed view - group settings, include",
-    },
-    3: {
-        "path": STATIC_FILES_DIR + "eval_singleruns_exclude.xml",
-        "name": "single runs - exclude fails & aborts (standard)",
-    },
-    4: {
-        "path": STATIC_FILES_DIR + "eval_singleruns_include.xml",
-        "name": "single runs - include fails & aborts (standard)",
-    },
-    5: {
-        "path": STATIC_FILES_DIR + "eval_singleruns_punish.xml",
-        "name": "single runs - punish fails & aborts (standard)",
-    },
-    6: {
-        "path": STATIC_FILES_DIR + "eval_singleruns_solved.xml",
-        "name": "single runs - fails & solved only (simplified)",
-    },
-    7: {
-        "path": STATIC_FILES_DIR + "eval_groupgithash_exclude.xml",
-        "name": "group by githash - exclude fails & aborts",
-    },
-    8: {
-        "path": STATIC_FILES_DIR + "eval_groupsettings_exclude.xml",
-        "name": "group by settings - exclude fails & aborts",
-    },
-    9: {
-        "path": STATIC_FILES_DIR + "eval_grouplpsolver_exclude.xml",
-        "name": "group by LP solver - exclude fails & aborts",
-    },
-    10: {
-        "path": STATIC_FILES_DIR + "evalperf_groupgithash_exclude_detailed.xml",
-        "name": "perf analysis - detailed, group githash, exclude",
-    },
-    11: {
-        "path": STATIC_FILES_DIR + "evalperf_groupsettings_exclude_detailed.xml",
-        "name": "perf analysis - detailed, group settings, exclude",
-    },
-    12: {
-        "path": STATIC_FILES_DIR + "papilo_evaluation.xml",
-        "name": "evaluation papilo",
-    },
-    13: {
-        "path": STATIC_FILES_DIR + "papilo_evaluation_solver_specific.xml",
-        "name": "evaluation papilo solver specific",
-    },
-    14: {
-        "path": STATIC_FILES_DIR + "papilo_evaluation_groupsettings.xml",
-        "name": "evaluation papilo group settings",
-    },
-}
-
-# date sorting works only with the empty NONE_DISPLAY at the moment
-NONE_DISPLAY = ""
-EXPORT_DATA_FORMATS = ("gzip", "json", "csv", "raw")
-EXPORT_FILE_TYPES = (".out", ".set", ".err", ".meta")
-
-FORMAT_DATE = "%Y-%m-%d"
-FORMAT_DATETIME_LONG = "%d. %b %Y, %H:%M"
-FORMAT_DATETIME_SHORT = "%d. %b %y"
-FORMAT_DATETIME = "%Y-%m-%d %H:%M:%S"
-
-EVAL_FILE = """<?xml version="1.0" ?>
-<!-- group by githash - exclude fails & aborts -->
-<Evaluation comparecolformat="%.3f" index="ProblemName Seed Permutation Settings LPSolver GitHash"
-indexsplit="3">
-    <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5"
-        comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit"
-        reduction="shmean shift. by 1">
+<?xml version="1.0" ?>
+<!-- single runs - fails & solved only (simplified) -->
+<Evaluation comparecolformat="%.3f" index="ProblemName RubberbandId" indexsplit="-1" suppressions="_abort_ _count_ _dualfail_ _limit_ _miss_ _primfail_ _time_ _unkn_">
+    <Column formatstr="%.2f" name="T" origcolname="SolvingTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="mean">
         <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
     </Column>
-    <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100"
-        reduction="shmean shift. by 100">
+    <Column formatstr="%.2f" name="NrmT" origcolname="NormalizedTime" minval="0.5" comp="quot shift. by 1" maxval="TimeLimit" alternative="TimeLimit" reduction="mean">
+        <Aggregation aggregation="shmean" name="sgm" shiftby="1.0"/>
+    </Column>
+    <Column formatstr="%.0f" name="N" origcolname="Nodes" comp="quot shift. by 100" reduction="mean">
         <Aggregation aggregation="shmean" name="sgm" shiftby="100.0" />
     </Column>
-    <FilterGroup name="\\cleaninst">
+    <FilterGroup name="all"/>
+    <FilterGroup name="clean">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
     </FilterGroup>
-    <FilterGroup active="True" filtertype="intersection" name="\\affected">
+    <FilterGroup active="True" filtertype="intersection" name="affected">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter active="True" anytestrun="one" datakey="LP_Iterations_dualLP" operator="diff"/>
-        <Filter active="True" anytestrun="one" expression1="_solved_"
-            expression2="1" operator="eq"/>
+        <Filter active="True" anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
     </FilterGroup>
-    <FilterGroup name="\\bracket{0}{tilim}">
+    <FilterGroup active="True" filtertype="intersection" name="unaffected">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="all" datakey="LP_Iterations_dualLP" operator="equal"/>
+    </FilterGroup>
+    <FilterGroup name="[0,tilim]">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
     </FilterGroup>
-    <FilterGroup name="\\bracket{1}{tilim}">
+    <FilterGroup name="[1,tilim]">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
         <Filter anytestrun="one" expression1="T" expression2="1" operator="ge"/>
     </FilterGroup>
-    <FilterGroup name="\\bracket{10}{tilim}">
+    <FilterGroup name="[10,tilim]">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
         <Filter anytestrun="one" expression1="T" expression2="10" operator="ge"/>
     </FilterGroup>
-    <FilterGroup name="\\bracket{100}{tilim}">
+    <FilterGroup name="[100,tilim]">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
         <Filter anytestrun="one" expression1="T" expression2="100" operator="ge"/>
     </FilterGroup>
-    <FilterGroup name="\\bracket{1000}{tilim}">
+    <FilterGroup name="[1000,tilim]">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
         <Filter anytestrun="one" expression1="T" expression2="1000" operator="ge"/>
     </FilterGroup>
-    <FilterGroup name="\\alloptimal">
+    <FilterGroup name="[0,10)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="all" expression1="T" expression2="10" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup name="[0,100)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
+        <Filter anytestrun="all" expression1="T" expression2="100" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup name="all-optimal">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_solved_" expression2="1" operator="eq"/>
     </FilterGroup>
-    <FilterGroup name="\\difftimeouts">
+    <FilterGroup name="diff-timeouts">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter anytestrun="one" expression1="_solved_" expression2="1" operator="eq"/>
         <Filter anytestrun="one" expression1="_solved_" expression2="0" operator="eq"/>
     </FilterGroup>
-    <FilterGroup active="True" filtertype="intersection" name="\\miplib~2017">
+    <FilterGroup active="True" filtertype="intersection" name="MIPLIB2017">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter active="True" anytestrun="all" datakey="ProblemName" operator="keep">
             <Value active="True" name="MIPLIB2017"/>
         </Filter>
     </FilterGroup>
-     <FilterGroup active="True" filtertype="intersection" name="\\nonconvex">
+    <FilterGroup active="True" filtertype="intersection" name="MIPLIB2010 (87)">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
         <Filter active="True" anytestrun="all" datakey="ProblemName" operator="keep">
+            <Value active="True" name="MIPLIB2010"/>
+        </Filter>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="MMM (168)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="one" datakey="ProblemName" operator="keep">
+            <Value active="True" name="MMM"/>
+        </Filter>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="MMM compl (387)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="one" datakey="ProblemName" operator="keep">
+            <Value active="True" name="air03"/>
+            <Value active="True" name="blend2"/>
+            <Value active="True" name="dcmulti"/>
+            <Value active="True" name="dsbmip"/>
+            <Value active="True" name="egout"/>
+            <Value active="True" name="enigma"/>
+            <Value active="True" name="flugpl"/>
+            <Value active="True" name="gt2"/>
+            <Value active="True" name="khb05250"/>
+            <Value active="True" name="lseu"/>
+            <Value active="True" name="misc03"/>
+            <Value active="True" name="misc06"/>
+            <Value active="True" name="mitre"/>
+            <Value active="True" name="mod008"/>
+            <Value active="True" name="p0201"/>
+            <Value active="True" name="p0282"/>
+            <Value active="True" name="p0548"/>
+            <Value active="True" name="qnet1"/>
+            <Value active="True" name="qnet1_o"/>
+            <Value active="True" name="rentacar"/>
+            <Value active="True" name="rgn"/>
+            <Value active="True" name="stein27"/>
+            <Value active="True" name="stein45"/>
+            <Value active="True" name="10teams"/>
+            <Value active="True" name="a1c1s1"/>
+            <Value active="True" name="aflow30a"/>
+            <Value active="True" name="aflow40b"/>
+            <Value active="True" name="air04"/>
+            <Value active="True" name="air05"/>
+            <Value active="True" name="arki001"/>
+            <Value active="True" name="atlanta-ip"/>
+            <Value active="True" name="cap6000"/>
+            <Value active="True" name="dano3mip"/>
+            <Value active="True" name="danoint"/>
+            <Value active="True" name="disctom"/>
+            <Value active="True" name="ds"/>
+            <Value active="True" name="fast0507"/>
+            <Value active="True" name="fiber"/>
+            <Value active="True" name="fixnet6"/>
+            <Value active="True" name="gesa2-o"/>
+            <Value active="True" name="gesa2"/>
+            <Value active="True" name="glass4"/>
+            <Value active="True" name="harp2"/>
+            <Value active="True" name="liu"/>
+            <Value active="True" name="manna81"/>
+            <Value active="True" name="markshare1"/>
+            <Value active="True" name="markshare2"/>
+            <Value active="True" name="mas74"/>
+            <Value active="True" name="mas76"/>
+            <Value active="True" name="misc07"/>
+            <Value active="True" name="mkc"/>
+            <Value active="True" name="mod011"/>
+            <Value active="True" name="modglob"/>
+            <Value active="True" name="momentum1"/>
+            <Value active="True" name="momentum2"/>
+            <Value active="True" name="momentum3"/>
+            <Value active="True" name="msc98-ip"/>
+            <Value active="True" name="mzzv11"/>
+            <Value active="True" name="mzzv42z"/>
+            <Value active="True" name="net12"/>
+            <Value active="True" name="noswot"/>
+            <Value active="True" name="nsrand-ipx"/>
+            <Value active="True" name="nw04"/>
+            <Value active="True" name="opt1217"/>
+            <Value active="True" name="p2756"/>
+            <Value active="True" name="pk1"/>
+            <Value active="True" name="pp08a"/>
+            <Value active="True" name="pp08aCUTS"/>
+            <Value active="True" name="protfold"/>
+            <Value active="True" name="qiu"/>
+            <Value active="True" name="rd-rplusc-21"/>
+            <Value active="True" name="roll3000"/>
+            <Value active="True" name="rout"/>
+            <Value active="True" name="set1ch"/>
+            <Value active="True" name="sp97ar"/>
+            <Value active="True" name="stp3d"/>
+            <Value active="True" name="swath"/>
+            <Value active="True" name="t1717"/>
+            <Value active="True" name="timtab1"/>
+            <Value active="True" name="timtab2"/>
+            <Value active="True" name="tr12-30"/>
+            <Value active="True" name="vpm2"/>
+            <Value active="True" name="b-ball"/>
+            <Value active="True" name="bab4"/>
+            <Value active="True" name="blp-ic98"/>
+            <Value active="True" name="cms750_4"/>
+            <Value active="True" name="drayage-0-20"/>
+            <Value active="True" name="drayage-100-24"/>
+            <Value active="True" name="drayage-25-2"/>
+            <Value active="True" name="drayage-50-31"/>
+            <Value active="True" name="drayage-50-7"/>
+            <Value active="True" name="drayage-75-5"/>
+            <Value active="True" name="eilD76-2"/>
+            <Value active="True" name="loopHA13"/>
+            <Value active="True" name="mc8"/>
+            <Value active="True" name="mine-166-10"/>
+            <Value active="True" name="neos11"/>
+            <Value active="True" name="neos12"/>
+            <Value active="True" name="ns2122698"/>
+            <Value active="True" name="ns25-pr3"/>
+            <Value active="True" name="ns25-pr9"/>
+            <Value active="True" name="ns60-pr3"/>
+            <Value active="True" name="ns60-pr9"/>
+            <Value active="True" name="opm2-z9-s14"/>
+            <Value active="True" name="reblock90"/>
+            <Value active="True" name="rocI-4-11"/>
+            <Value active="True" name="sing290"/>
+            <Value active="True" name="tanglegram3"/>
+            <Value active="True" name="valueatrisk"/>
+            <Value active="True" name="30n20b8"/>
+            <Value active="True" name="50v-10"/>
+            <Value active="True" name="acc-tight4"/>
+            <Value active="True" name="acc-tight5"/>
+            <Value active="True" name="acc-tight6"/>
+            <Value active="True" name="app1-2"/>
+            <Value active="True" name="ash608gpia-3col"/>
+            <Value active="True" name="atm20-100"/>
+            <Value active="True" name="b2c1s1"/>
+            <Value active="True" name="bab1"/>
+            <Value active="True" name="bab3"/>
+            <Value active="True" name="bab5"/>
+            <Value active="True" name="beasleyC3"/>
+            <Value active="True" name="berlin_5_8_0"/>
+            <Value active="True" name="bg512142"/>
+            <Value active="True" name="biella1"/>
+            <Value active="True" name="bienst2"/>
+            <Value active="True" name="binkar10_1"/>
+            <Value active="True" name="bley_xl1"/>
+            <Value active="True" name="blp-ar98"/>
+            <Value active="True" name="blp-ic97"/>
+            <Value active="True" name="bnatt350"/>
+            <Value active="True" name="bnatt400"/>
+            <Value active="True" name="buildingenergy"/>
+            <Value active="True" name="cdma"/>
+            <Value active="True" name="circ10-3"/>
+            <Value active="True" name="co-100"/>
+            <Value active="True" name="core2536-691"/>
+            <Value active="True" name="core4872-1529"/>
+            <Value active="True" name="cov1075"/>
+            <Value active="True" name="csched007"/>
+            <Value active="True" name="csched008"/>
+            <Value active="True" name="csched010"/>
+            <Value active="True" name="datt256"/>
+            <Value active="True" name="dc1c"/>
+            <Value active="True" name="dc1l"/>
+            <Value active="True" name="dfn-gwin-UUM"/>
+            <Value active="True" name="dg012142"/>
+            <Value active="True" name="dolom1"/>
+            <Value active="True" name="ds-big"/>
+            <Value active="True" name="eil33-2"/>
+            <Value active="True" name="eilA101-2"/>
+            <Value active="True" name="eilB101"/>
+            <Value active="True" name="enlight13"/>
+            <Value active="True" name="enlight14"/>
+            <Value active="True" name="enlight15"/>
+            <Value active="True" name="enlight16"/>
+            <Value active="True" name="enlight9"/>
+            <Value active="True" name="ex10"/>
+            <Value active="True" name="ex1010-pi"/>
+            <Value active="True" name="ex9"/>
+            <Value active="True" name="f2000"/>
+            <Value active="True" name="g200x740i"/>
+            <Value active="True" name="ger50_17_trans"/>
+            <Value active="True" name="germany50-DBM"/>
+            <Value active="True" name="gmu-35-40"/>
+            <Value active="True" name="gmu-35-50"/>
+            <Value active="True" name="gmut-75-50"/>
+            <Value active="True" name="gmut-77-40"/>
+            <Value active="True" name="go19"/>
+            <Value active="True" name="hanoi5"/>
+            <Value active="True" name="hawaiiv10-130"/>
+            <Value active="True" name="ic97_potential"/>
+            <Value active="True" name="iis-100-0-cov"/>
+            <Value active="True" name="iis-bupa-cov"/>
+            <Value active="True" name="iis-pima-cov"/>
+            <Value active="True" name="in"/>
+            <Value active="True" name="ivu06-big"/>
+            <Value active="True" name="ivu52"/>
+            <Value active="True" name="janos-us-DDM"/>
+            <Value active="True" name="k16x240"/>
+            <Value active="True" name="lectsched-1-obj"/>
+            <Value active="True" name="lectsched-1"/>
+            <Value active="True" name="lectsched-2"/>
+            <Value active="True" name="lectsched-3"/>
+            <Value active="True" name="lectsched-4-obj"/>
+            <Value active="True" name="lotsize"/>
+            <Value active="True" name="lrsa120"/>
+            <Value active="True" name="m100n500k4r1"/>
+            <Value active="True" name="macrophage"/>
+            <Value active="True" name="map06"/>
+            <Value active="True" name="map10"/>
+            <Value active="True" name="map14"/>
+            <Value active="True" name="map18"/>
+            <Value active="True" name="map20"/>
+            <Value active="True" name="markshare_5_0"/>
+            <Value active="True" name="maxgasflow"/>
+            <Value active="True" name="mc11"/>
+            <Value active="True" name="mcsched"/>
+            <Value active="True" name="methanosarcina"/>
+            <Value active="True" name="mik-250-1-100-1"/>
+            <Value active="True" name="mine-166-5"/>
+            <Value active="True" name="mine-90-10"/>
+            <Value active="True" name="mining"/>
+            <Value active="True" name="mspp16"/>
+            <Value active="True" name="n15-3"/>
+            <Value active="True" name="n3-3"/>
+            <Value active="True" name="n3700"/>
+            <Value active="True" name="n3705"/>
+            <Value active="True" name="n370a"/>
+            <Value active="True" name="n3div36"/>
+            <Value active="True" name="n3seq24"/>
+            <Value active="True" name="n4-3"/>
+            <Value active="True" name="n9-3"/>
+            <Value active="True" name="nb10tb"/>
+            <Value active="True" name="neos-1109824"/>
+            <Value active="True" name="neos-1337307"/>
+            <Value active="True" name="neos-1396125"/>
+            <Value active="True" name="neos-1601936"/>
+            <Value active="True" name="neos-476283"/>
+            <Value active="True" name="neos-686190"/>
+            <Value active="True" name="neos-777800"/>
+            <Value active="True" name="neos-799711"/>
+            <Value active="True" name="neos-807456"/>
+            <Value active="True" name="neos-849702"/>
+            <Value active="True" name="neos-916792"/>
+            <Value active="True" name="neos-934278"/>
+            <Value active="True" name="neos13"/>
+            <Value active="True" name="neos15"/>
+            <Value active="True" name="neos16"/>
+            <Value active="True" name="neos18"/>
+            <Value active="True" name="neos6"/>
+            <Value active="True" name="neos788725"/>
+            <Value active="True" name="neos808444"/>
+            <Value active="True" name="neos858960"/>
+            <Value active="True" name="netdiversion"/>
+            <Value active="True" name="newdano"/>
+            <Value active="True" name="nobel-eu-DBE"/>
+            <Value active="True" name="ns1111636"/>
+            <Value active="True" name="ns1116954"/>
+            <Value active="True" name="ns1158817"/>
+            <Value active="True" name="ns1208400"/>
+            <Value active="True" name="ns1456591"/>
+            <Value active="True" name="ns1606230"/>
+            <Value active="True" name="ns1631475"/>
+            <Value active="True" name="ns1644855"/>
+            <Value active="True" name="ns1663818"/>
+            <Value active="True" name="ns1685374"/>
+            <Value active="True" name="ns1686196"/>
+            <Value active="True" name="ns1688347"/>
+            <Value active="True" name="ns1696083"/>
+            <Value active="True" name="ns1702808"/>
+            <Value active="True" name="ns1745726"/>
+            <Value active="True" name="ns1758913"/>
+            <Value active="True" name="ns1766074"/>
+            <Value active="True" name="ns1769397"/>
+            <Value active="True" name="ns1778858"/>
+            <Value active="True" name="ns1830653"/>
+            <Value active="True" name="ns1853823"/>
+            <Value active="True" name="ns1854840"/>
+            <Value active="True" name="ns1856153"/>
+            <Value active="True" name="ns1904248"/>
+            <Value active="True" name="ns1905797"/>
+            <Value active="True" name="ns1905800"/>
+            <Value active="True" name="ns1952667"/>
+            <Value active="True" name="ns2017839"/>
+            <Value active="True" name="ns2081729"/>
+            <Value active="True" name="ns2118727"/>
+            <Value active="True" name="ns2122603"/>
+            <Value active="True" name="ns2124243"/>
+            <Value active="True" name="ns2137859"/>
+            <Value active="True" name="ns4-pr3"/>
+            <Value active="True" name="ns4-pr9"/>
+            <Value active="True" name="ns894236"/>
+            <Value active="True" name="ns894244"/>
+            <Value active="True" name="ns894786"/>
+            <Value active="True" name="ns894788"/>
+            <Value active="True" name="ns903616"/>
+            <Value active="True" name="ns930473"/>
+            <Value active="True" name="nsr8k"/>
+            <Value active="True" name="nu120-pr3"/>
+            <Value active="True" name="nu60-pr9"/>
+            <Value active="True" name="ofi"/>
+            <Value active="True" name="opm2-z10-s2"/>
+            <Value active="True" name="opm2-z11-s8"/>
+            <Value active="True" name="opm2-z12-s14"/>
+            <Value active="True" name="opm2-z12-s7"/>
+            <Value active="True" name="opm2-z7-s2"/>
+            <Value active="True" name="p100x588b"/>
+            <Value active="True" name="p2m2p1m1p0n100"/>
+            <Value active="True" name="p80x400b"/>
+            <Value active="True" name="pb-simp-nonunif"/>
+            <Value active="True" name="pg5_34"/>
+            <Value active="True" name="pigeon-10"/>
+            <Value active="True" name="pigeon-11"/>
+            <Value active="True" name="pigeon-12"/>
+            <Value active="True" name="pigeon-13"/>
+            <Value active="True" name="pigeon-19"/>
+            <Value active="True" name="probportfolio"/>
+            <Value active="True" name="pw-myciel4"/>
+            <Value active="True" name="queens-30"/>
+            <Value active="True" name="r80x800"/>
+            <Value active="True" name="rail01"/>
+            <Value active="True" name="rail02"/>
+            <Value active="True" name="rail03"/>
+            <Value active="True" name="rail507"/>
+            <Value active="True" name="ran14x18-disj-8"/>
+            <Value active="True" name="ran16x16"/>
+            <Value active="True" name="reblock166"/>
+            <Value active="True" name="reblock354"/>
+            <Value active="True" name="reblock420"/>
+            <Value active="True" name="reblock67"/>
+            <Value active="True" name="rmatr100-p10"/>
+            <Value active="True" name="rmatr100-p5"/>
+            <Value active="True" name="rmatr200-p10"/>
+            <Value active="True" name="rmatr200-p20"/>
+            <Value active="True" name="rmatr200-p5"/>
+            <Value active="True" name="rmine10"/>
+            <Value active="True" name="rmine14"/>
+            <Value active="True" name="rmine21"/>
+            <Value active="True" name="rmine25"/>
+            <Value active="True" name="rmine6"/>
+            <Value active="True" name="rocII-4-11"/>
+            <Value active="True" name="rocII-7-11"/>
+            <Value active="True" name="rocII-9-11"/>
+            <Value active="True" name="rococoB10-011000"/>
+            <Value active="True" name="rococoC10-001000"/>
+            <Value active="True" name="rococoC11-011100"/>
+            <Value active="True" name="rococoC12-111000"/>
+            <Value active="True" name="rvb-sub"/>
+            <Value active="True" name="satellites1-25"/>
+            <Value active="True" name="satellites2-60-fs"/>
+            <Value active="True" name="satellites2-60"/>
+            <Value active="True" name="satellites3-40-fs"/>
+            <Value active="True" name="satellites3-40"/>
+            <Value active="True" name="sct1"/>
+            <Value active="True" name="sct32"/>
+            <Value active="True" name="sct5"/>
+            <Value active="True" name="set3-10"/>
+            <Value active="True" name="set3-15"/>
+            <Value active="True" name="set3-20"/>
+            <Value active="True" name="seymour"/>
+            <Value active="True" name="seymour-disj-10"/><Value active="True" name="seymour.disj-10"/>
+            <Value active="True" name="shipsched"/>
+            <Value active="True" name="shs1023"/>
+            <Value active="True" name="siena1"/>
+            <Value active="True" name="sing161"/>
+            <Value active="True" name="sing2"/>
+            <Value active="True" name="sing245"/>
+            <Value active="True" name="sing359"/>
+            <Value active="True" name="sp98ic"/>
+            <Value active="True" name="sp98ir"/>
+            <Value active="True" name="splan1"/>
+            <Value active="True" name="stockholm"/>
+            <Value active="True" name="sts405"/>
+            <Value active="True" name="sts729"/>
+            <Value active="True" name="t1722"/>
+            <Value active="True" name="tanglegram1"/>
+            <Value active="True" name="tanglegram2"/>
+            <Value active="True" name="toll-like"/>
+            <Value active="True" name="transportmoment"/>
+            <Value active="True" name="triptim1"/>
+            <Value active="True" name="triptim2"/>
+            <Value active="True" name="triptim3"/>
+            <Value active="True" name="tw-myciel4"/>
+            <Value active="True" name="uc-case11"/>
+            <Value active="True" name="uc-case3"/>
+            <Value active="True" name="uct-subprob"/>
+            <Value active="True" name="umts"/>
+            <Value active="True" name="unitcal_7"/>
+            <Value active="True" name="usAbbrv-8-25_70"/>
+            <Value active="True" name="van"/>
+            <Value active="True" name="vpphard"/>
+            <Value active="True" name="vpphard2"/>
+            <Value active="True" name="wachplan"/>
+            <Value active="True" name="wnq-n100-mw99-14"/>
+            <Value active="True" name="zib01"/>
+            <Value active="True" name="zib02"/>
+            <Value active="True" name="zib54-UUE"/>
+            <Value active="True" name="bell3a"/>
+            <Value active="True" name="bell5"/>
+            <Value active="True" name="gen"/>
+            <Value active="True" name="gesa3"/>
+            <Value active="True" name="gesa3_o"/>
+            <Value active="True" name="l152lav"/>
+            <Value active="True" name="mod010"/>
+            <Value active="True" name="p0033"/>
+            <Value active="True" name="vpm1"/>
+        </Filter>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="Cor@l (349)">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="one" datakey="ProblemName" operator="keep">
+            <Value active="True" name="COR@L"/>
+        </Filter>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="continuous">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="PresolvedProblem_ContVars" expression2="PresolvedProblem_Vars" operator="eq"/>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="integer">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="PresolvedProblem_ContVars" expression2="PresolvedProblem_Vars" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="diff-contint">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter anytestrun="one" expression1="PresolvedProblem_ContVars" expression2="PresolvedProblem_Vars" operator="eq"/>
+        <Filter anytestrun="one" expression1="PresolvedProblem_ContVars" expression2="PresolvedProblem_Vars" operator="lt"/>
+    </FilterGroup>
+    <FilterGroup active="True" filtertype="intersection" name="nonconvex">
+        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
+        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
+        <Filter active="True" anytestrun="one" datakey="ProblemName" operator="keep">
             <Value active="True" name="4stufen"/>
             <Value active="True" name="alkyl"/>
             <Value active="True" name="alkylation"/>
@@ -1376,10 +1728,10 @@ indexsplit="3">
             <Value active="True" name="worst"/>
         </Filter>
     </FilterGroup>
-    <FilterGroup active="True" filtertype="intersection" name="\\convex">
+    <FilterGroup active="True" filtertype="intersection" name="convex">
         <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
         <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
-        <Filter active="True" anytestrun="all" datakey="ProblemName" operator="keep">
+        <Filter active="True" anytestrun="one" datakey="ProblemName" operator="keep">
             <Value active="True" name="abel"/>
             <Value active="True" name="alan"/>
             <Value active="True" name="arki0001"/>
@@ -1758,24 +2110,4 @@ indexsplit="3">
             <Value active="True" name="watercontamination0303r"/>
         </Filter>
     </FilterGroup>
-    <FilterGroup active="True" filtertype="intersection" name="\\coral">
-        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
-        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
-        <Filter active="True" anytestrun="one" datakey="ProblemName" operator="keep">
-            <Value active="True" name="COR@L"/>
-        </Filter>
-    </FilterGroup>
-    <FilterGroup active="True" filtertype="intersection" name="continuous">
-        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
-        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
-        <Filter anytestrun="all" expression1="PresolvedProblem_ContVars"
-            expression2="PresolvedProblem_Vars" operator="eq"/>
-    </FilterGroup>
-    <FilterGroup active="True" filtertype="intersection" name="integer">
-        <Filter anytestrun="all" expression1="_abort_" expression2="0" operator="eq"/>
-        <Filter anytestrun="all" expression1="_fail_" expression2="0" operator="eq"/>
-        <Filter anytestrun="all" expression1="PresolvedProblem_ContVars"
-            expression2="PresolvedProblem_Vars" operator="lt"/>
-    </FilterGroup>
 </Evaluation>
-"""


### PR DESCRIPTION
Originally requested by @pfetsch 

Adds an evaluation with reduced columns: #solved, #fails, and shifted geometric means of time and nodes. Same filter groups as the standard single-runs evaluation, only fewer columns.

Also applies the evaluation's `suppressions` attribute to the aggregated table. ipet only applies it when streaming a table to a file, so it had no effect in rubberband before; without it the counter columns cannot be reduced from the xml. No existing evaluation sets the attribute, so nothing else changes.